### PR TITLE
Fix user profile flow to ensure profile creation and fetching

### DIFF
--- a/GamingApp.Web/Components/Pages/Account/UserPage.razor
+++ b/GamingApp.Web/Components/Pages/Account/UserPage.razor
@@ -144,6 +144,7 @@
         if (result is { Cancelled: false, Data: CreateUserProfileModel model })
         {
             await CreateGameAccount(model.InGameUserName);
+            _userProfile = await UserApi.GetUserProfileAsync();
         }
     }
 
@@ -152,6 +153,7 @@
         try
         {
             _userProfile = await UserApi.CreateUserProfileAsync(inGameUserName);
+            _userProfile = await UserApi.GetUserProfileAsync();
             ToastService.ShowSuccess("Game Account created successfully!");
         }
         catch (Exception ex)


### PR DESCRIPTION
Update the Get/Post userProfile flow to create a new profile if the Identity user doesn't have a related db profile, and return the stored db profile if it exists.

* **GamingApp.ApiService/Endpoints/UserEndpoints.cs**
  - Update `GetUserProfileEndpoint` to use `UserHelper.EnsureUserExistsAsync` to ensure user exists before fetching profile.
  - Update `CreateUserProfileEndpoint` to use `UserHelper.EnsureUserExistsAsync` to ensure user exists before creating profile.
  - Remove redundant code for fetching and creating user profiles.

* **GamingApp.Web/Components/Pages/Account/UserPage.razor**
  - Update `PromptCreateAccount` method to call `UserApi.GetUserProfileAsync` after creating account to ensure profile is fetched.
  - Update `CreateGameAccount` method to call `UserApi.GetUserProfileAsync` after creating account to ensure profile is fetched.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/fiskkrok/GamingApp?shareId=e40e1193-609a-4f10-a9b8-ee2fd0626702).